### PR TITLE
fix: drop replace directive in favor of using a workspace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/joshdk/buildversion v0.1.0
-	github.com/joshdk/modfmt/pkg/modfmt v0.0.0-00010101000000-000000000000
+	github.com/joshdk/modfmt/pkg/modfmt v0.0.0-20250905173720-12db062242fe
 	github.com/spf13/cobra v1.10.1
 )
 
@@ -12,8 +12,4 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/mod v0.27.0 // indirect
-)
-
-replace (
-	github.com/joshdk/modfmt/pkg/modfmt => ./pkg/modfmt
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joshdk/buildversion v0.1.0 h1:AeCFYqV2zZI6Q5pUDNi9YzX15Kmm7UnHKsC8yN2YIsk=
 github.com/joshdk/buildversion v0.1.0/go.mod h1:M/dUoVcv7TeUJ72r8NdyccLHO/7aaKUT8CdKOSb6FfU=
+github.com/joshdk/modfmt/pkg/modfmt v0.0.0-20250905173720-12db062242fe h1:49otKRx9Rqu6pBcKDgOWlWwfkRJb4Fn2Tk5CeaO89xo=
+github.com/joshdk/modfmt/pkg/modfmt v0.0.0-20250905173720-12db062242fe/go.mod h1:vr6m7whffrB4/caMsQHuwGg+M6T9wDSZFT1la+vQJyA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=

--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.25.0
+
+use (
+	.
+	./pkg/modfmt
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,6 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
+golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Using `replace (...)` directives prevents the module from being compatible with `go install`.