### PR TITLE
chore: duplicate license file into sub-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ This code is distributed under the [MIT License][license-link], see [LICENSE.txt
 [github-release-badge]:  https://img.shields.io/github/release/joshdk/modfmt/all.svg
 [github-release-link]:   https://github.com/joshdk/modfmt/releases
 [godoc-badge]:           https://pkg.go.dev/badge/github.com/joshdk/modfmt/pkg/modfmt
-[godoc-link]:            https://pkg.go.dev//github.com/joshdk/modfmt/pkg/modfmt
+[godoc-link]:            https://pkg.go.dev/github.com/joshdk/modfmt/pkg/modfmt
 [license-badge]:         https://img.shields.io/badge/license-MIT-green.svg
 [license-file]:          https://github.com/joshdk/modfmt/blob/master/LICENSE.txt
 [license-link]:          https://opensource.org/licenses/MIT

--- a/pkg/modfmt/LICENSE.txt
+++ b/pkg/modfmt/LICENSE.txt
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) Josh Komoroske
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
pkg.go.dev refuses to display module information unless a license file is present.